### PR TITLE
Add Scrollbars for Stream Lists

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,14 @@
+.card-body.expanded {
+    max-height: 400px;
+    overflow-y: auto;
+    padding-right: 10px;
+}
+
+.card-body.expanded::-webkit-scrollbar {
+    width: 8px;
+}
+
+.card-body.expanded::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.3);
+    border-radius: 4px;
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,6 +1,3 @@
-.card-header i {
-    transition: transform 0.3s ease;
-}
 .card-body.expanded {
     max-height: 400px;
     overflow-y: auto;

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,3 +1,6 @@
+.card-header i {
+    transition: transform 0.3s ease;
+}
 .card-body.expanded {
     max-height: 400px;
     overflow-y: auto;

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}M3U Monitor{% endblock %}</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; background-color: #f0f2f5; color: #333; margin: 0; padding: 0; }
         .navbar { background-color: #ffffff; overflow: hidden; border-bottom: 1px solid #dee2e6; box-shadow: 0 2px 4px rgba(0,0,0,0.1); display: flex; align-items: center; padding: 0 20px; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,27 +76,10 @@
 
 <script>
 function toggleCard(headerElement) {
-    const clickedCard = headerElement.closest('.source-card');
-    const clickedBody = clickedCard.querySelector('.card-body');
-    const clickedIcon = headerElement.querySelector('i');
-
-    const allCards = document.querySelectorAll('.source-card');
-
-    allCards.forEach(card => {
-        const body = card.querySelector('.card-body');
-        const icon = card.querySelector('.card-header i');
-
-        if (card === clickedCard) {
-            // Toggle the clicked one
-            const isExpanded = body.classList.contains('expanded');
-            body.classList.toggle('expanded', !isExpanded);
-            icon.style.transform = !isExpanded ? 'rotate(180deg)' : 'rotate(0deg)';
-        } else {
-            // Collapse all others
-            body.classList.remove('expanded');
-            icon.style.transform = 'rotate(0deg)';
-        }
-    });
-}
+        const cardBody = headerElement.nextElementSibling;
+        const icon = headerElement.querySelector('i');
+        cardBody.classList.toggle('expanded');
+        icon.style.transform = cardBody.classList.contains('expanded') ? 'rotate(180deg)' : 'rotate(0deg)';
+    }
 </script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,11 +75,28 @@
 </div>
 
 <script>
-    function toggleCard(headerElement) {
-        const cardBody = headerElement.nextElementSibling;
-        const icon = headerElement.querySelector('i');
-        cardBody.classList.toggle('expanded');
-        icon.style.transform = cardBody.classList.contains('expanded') ? 'rotate(180deg)' : 'rotate(0deg)';
-    }
+function toggleCard(headerElement) {
+    const clickedCard = headerElement.closest('.source-card');
+    const clickedBody = clickedCard.querySelector('.card-body');
+    const clickedIcon = headerElement.querySelector('i');
+
+    const allCards = document.querySelectorAll('.source-card');
+
+    allCards.forEach(card => {
+        const body = card.querySelector('.card-body');
+        const icon = card.querySelector('.card-header i');
+
+        if (card === clickedCard) {
+            // Toggle the clicked one
+            const isExpanded = body.classList.contains('expanded');
+            body.classList.toggle('expanded', !isExpanded);
+            icon.style.transform = !isExpanded ? 'rotate(180deg)' : 'rotate(0deg)';
+        } else {
+            // Collapse all others
+            body.classList.remove('expanded');
+            icon.style.transform = 'rotate(0deg)';
+        }
+    });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
Changes

- Created static/styles.css to hold custom CSS for UI enhancements.
- Added scroll behavior to .card-body.expanded to limit height and enable vertical scrolling:

```
.card-body.expanded {
    max-height: 400px;
    overflow-y: auto;
    padding-right: 10px;
}
```

- Included the new stylesheet in base.html via:

`<link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">`

- Ensured static/ is tracked by Git by committing styles.css (Git doesn't track empty folders).
- Verified that stream lists now scroll cleanly within their cards, improving dashboard usability.

Tested

- Confirmed scrollbar behavior works in both Chrome and Firefox.
- Ensured no visual regressions in navbar or layout.
- Stream logos and card titles remain unaffected.